### PR TITLE
Basic tracker creation logic

### DIFF
--- a/src/sagemaker/experiments/tracker.py
+++ b/src/sagemaker/experiments/tracker.py
@@ -47,8 +47,7 @@ class Tracker(object):
     def _create_trial_component(self, component_name, display_name):
         """Placeholder docstring"""
         self.sagemaker_boto_client.create_trial_component(
-            TrialComponentName=component_name,
-            DisplayName=display_name
+            TrialComponentName=component_name, DisplayName=display_name
         )
 
     @staticmethod

--- a/tests/unit/test_tracker.py
+++ b/tests/unit/test_tracker.py
@@ -69,14 +69,11 @@ def test_create_tracker_in_training_job_failed_mode(mock_boto_client):
 @mock.patch.object(uuid, "uuid4")
 def test_create_tracker_in_notebook(mock_uuid, mock_boto_client):
     mock_uuid.return_value = "uuid"
-    tracker = Tracker(
-        display_name="Training", sagemaker_boto_client=mock_boto_client
-    )
+    tracker = Tracker(display_name="Training", sagemaker_boto_client=mock_boto_client)
     assert tracker.component_name == "Training-uuid"
     assert not tracker.failed_mode
     mock_boto_client.create_trial_component.assert_called_once_with(
-        TrialComponentName=tracker.component_name,
-        DisplayName="Training",
+        TrialComponentName=tracker.component_name, DisplayName="Training"
     )
 
 
@@ -89,8 +86,7 @@ def test_create_tracker_in_notebook_no_source_arn(mock_uuid, mock_boto_client):
     assert tracker.component_name == "PreProcessing-uuid"
     assert not tracker.failed_mode
     mock_boto_client.create_trial_component.assert_called_once_with(
-        TrialComponentName=tracker.component_name,
-        DisplayName="PreProcessing",
+        TrialComponentName=tracker.component_name, DisplayName="PreProcessing"
     )
 
 


### PR DESCRIPTION
* If in training job
  - Fetch training job arn from env var and try to fetch the component arn which was auto-created
  - If eureka has troubles or there is delay in auto-creation, we enter fail-safe mode. This is to avoid customer impact due to eureka downtime.

* If in notebook
  - create the trial component


Since the Eureka APIs are not up post model changes, I really dont know if the boto calls actually or the request/response format is correct.

```
tests/unit/test_tracker.py::test_tracker_gets_default_boto_client_if_none_supplied PASSED                                                                                                                                                                                      [ 16%]
tests/unit/test_tracker.py::test_create_tracker_in_training_job PASSED                                                                                                                                                                                                         [ 33%]
tests/unit/test_tracker.py::test_create_tracker_in_training_job_failed_mode PASSED                                                                                                                                                                                             [ 50%]
tests/unit/test_tracker.py::test_create_tracker_in_notebook PASSED                                                                                                                                                                                                             [ 66%]
tests/unit/test_tracker.py::test_create_tracker_in_notebook_no_source_arn PASSED                                                                                                                                                                                               [ 83%]
tests/unit/test_tracker.py::test_create_tracker_in_notebook_no_display_name PASSED                                                                                                                                                                                             [100%]

============================================================================================================================== 6 passed in 0.41 seconds ==============================================================================================================================
```