### PR TITLE
skip auto create tests

### DIFF
--- a/tests/integ-jobs/test_track_from_training_job.py
+++ b/tests/integ-jobs/test_track_from_training_job.py
@@ -59,6 +59,7 @@ def wait_for_job(job, sagemaker_client):
                 sys.stdout.flush()
                 time.sleep(30)
 
+
 @pytest.mark.skip(reason="to be only run manually, integ/canaries already cover this scenario")
 def test_track_from_training_job(sagemaker_boto_client, training_job_name):
     tj = sagemaker_boto_client.describe_training_job(TrainingJobName=training_job_name)


### PR DESCRIPTION
these tests are consistently failing and slow. there is a sim to improve them, skip them for now.