### PR TITLE
add documentation generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+docs/_static/
+docs/_template/

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,11 @@ SageMaker Experiments Python SDK
 
 .. image:: https://img.shields.io/pypi/l/sagemaker-experiments
     :target: https://github.com/aws/sagemaker-experiments/blob/master/LICENSE
+    :alt: License
+
+.. image:: https://readthedocs.org/projects/sagemaker-experiments/badge/?version=stable
+    :target: https://sagemaker-experiments.readthedocs.io/en/stable/?badge=stable
+    :alt: Documentation Status
 
 .. image:: https://img.shields.io/pypi/dm/sagemaker-experiments
     :target: https://pypi.python.org/pypi/sagemaker-experiments
@@ -58,6 +63,10 @@ SageMaker Experiments Python SDK
     :target: https://github.com/python/black
     :alt: Code style: black
 
+.. image:: https://readthedocs.org/projects/sagemaker-experiments/badge/?version=latest&style=plastic
+    :target: https://readthedocs.org/projects/sagemaker-experiments/
+    :alt: Read the Docs - Sagemaker Experiments
+
 
 
 Experiment tracking in SageMaker Training Jobs, Processing Jobs, and Notebooks.
@@ -67,6 +76,8 @@ Overview
 SageMaker Experiments is an AWS service for tracking machine learning Experiments. The SageMaker Experiments Python SDK is a high-level interface to this service that helps you track Experiment information using Python.
 
 Experiment tracking powers the machine learning integrated development environment `Amazon SageMaker Studio <https://docs.aws.amazon.com/sagemaker/latest/dg/gs-studio.html>`_.
+
+For detailed API reference please go to: `Read the Docs <https://sagemaker-experiments.readthedocs.io>`_
 
 Concepts
 --------

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,78 @@
+# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from datetime import datetime
+import pkg_resources
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('..'))
+
+# -- Project information -----------------------------------------------------
+
+project = 'sagemaker-experiments'
+copyright = u"%s, Amazon" % datetime.now().year
+author = 'Amazon Web Services'
+version = pkg_resources.require(project)[0].version
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.coverage",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autosectionlabel",
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+source_suffix = ".rst"  # The suffix of source filenames.
+master_doc = "index"  # The master toctree document.
+
+# The full version, including alpha/beta/rc tags.
+release = version
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+exclude_trees = ["_build"]
+
+pygments_style = "default"
+autoclass_content = "both"
+#autodoc_default_options = {"show-inheritance", "members", "undoc-members"}
+autodoc_member_order = "bysource"
+if "READTHEDOCS" in os.environ:
+    html_theme = "default"
+else:
+    html_theme = "haiku"
+html_static_path = []
+htmlhelp_basename = "%sdoc" % project
+
+# Example configuration for intersphinx: refer to the Python standard library.
+intersphinx_mapping = {"http://docs.python.org/": None}
+
+# autosummary
+autosummary_generate = True
+
+# autosectionlabel
+autosectionlabel_prefix_document = True

--- a/docs/experiment.rst
+++ b/docs/experiment.rst
@@ -1,0 +1,7 @@
+Experiment
+----------
+
+.. autoclass:: smexperiments.experiment.Experiment
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,11 @@
+Amazon SageMaker Experiments Python SDK
+=======================================
+
+.. toctree::
+    :maxdepth: 1
+
+    tracker
+    experiment
+    trial
+    trial_component
+    metrics

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -1,0 +1,7 @@
+Metrics
+-------
+
+.. automodule:: smexperiments.metrics
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/tracker.rst
+++ b/docs/tracker.rst
@@ -1,0 +1,7 @@
+Tracker
+-------
+
+.. autoclass:: smexperiments.tracker.Tracker
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/trial.rst
+++ b/docs/trial.rst
@@ -1,0 +1,7 @@
+Trial
+-----
+
+.. autoclass:: smexperiments.trial.Trial
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/trial_component.rst
+++ b/docs/trial_component.rst
@@ -1,0 +1,7 @@
+Trial Component
+---------------
+
+.. autoclass:: smexperiments.trial_component.TrialComponent
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/tox.ini
+++ b/tox.ini
@@ -114,3 +114,18 @@ deps =
     boto3 >= 1.10.32
     pytest
     docker
+
+[testenv:docs]
+basepython = python3
+changedir = docs
+deps =
+    Pygments
+    docutils
+    alabaster
+    commonmark
+    recommonmark
+    sphinx
+    sphinx-rtd-theme
+    readthedocs-sphinx-ext
+commands =
+    sphinx-build -T -W -b html -d _build/doctrees-readthedocs -D language=en . _build/html


### PR DESCRIPTION
add documentation generation with sphinx

```
╰ tox -e docs
GLOB sdist-make: /Users/danabens/workplace/github/sagemaker-experiments/setup.py
docs inst-nodeps: /Users/danabens/workplace/github/sagemaker-experiments/.tox/.tmp/package/1/sagemaker-experiments-0.1.4.zip
docs installed: alabaster==0.7.12,apipkg==1.5,atomicwrites==1.3.0,attrs==19.3.0,Babel==2.8.0,boto3==1.11.3,botocore==1.14.3,certifi==2019.11.28,chardet==3.0.4,commonmark==0.9.1,coverage==5.0.3,docutils==0.15.2,entrypoints==0.3,execnet==1.7.1,filelock==3.0.12,flake8==3.7.9,idna==2.8,imagesize==1.2.0,importlib-metadata==0.23,Jinja2==2.10.3,jmespath==0.9.4,MarkupSafe==1.1.1,mccabe==0.6.1,more-itertools==8.1.0,packaging==20.0,pathlib2==2.3.5,pluggy==0.13.1,py==1.8.1,pycodestyle==2.5.0,pyflakes==2.1.1,Pygments==2.5.2,pyparsing==2.4.6,pytest==4.4.1,pytest-cov==2.8.1,pytest-cover==3.0.0,pytest-coverage==0.0,pytest-forked==1.1.3,pytest-rerunfailures==8.0,pytest-xdist==1.31.0,python-dateutil==2.8.1,pytz==2019.3,readthedocs-sphinx-ext==1.0.1,recommonmark==0.6.0,requests==2.22.0,s3transfer==0.3.0,sagemaker-experiments==0.1.4,six==1.14.0,snowballstemmer==2.0.0,Sphinx==2.3.1,sphinx-rtd-theme==0.4.3,sphinxcontrib-applehelp==1.0.1,sphinxcontrib-devhelp==1.0.1,sphinxcontrib-htmlhelp==1.0.2,sphinxcontrib-jsmath==1.0.1,sphinxcontrib-qthelp==1.0.2,sphinxcontrib-serializinghtml==1.1.3,toml==0.10.0,tox==3.13.1,urllib3==1.25.7,virtualenv==16.7.9,zipp==1.0.0
docs run-test-pre: PYTHONHASHSEED='2053742765'
docs run-test: commands[0] | sphinx-build -T -W -b html -d _build/doctrees-readthedocs -D language=en . _build/html
Running Sphinx v2.3.1
loading translations [en]... done
loading pickled environment... done
[autosummary] generating autosummary for: experiment.rst, index.rst, metrics.rst, tracker.rst, trial.rst, trial_component.rst
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 6 changed, 0 removed
reading sources... [ 16%] experiment
reading sources... [ 33%] index
reading sources... [ 50%] metrics
reading sources... [ 66%] tracker
reading sources... [ 83%] trial
reading sources... [100%] trial_component

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [ 16%] experiment
writing output... [ 33%] index
writing output... [ 50%] metrics
writing output... [ 66%] tracker
writing output... [ 83%] trial
writing output... [100%] trial_component

generating indices...  genindex py-modindexdone
writing additional pages...  searchdone
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in _build/html.
________________________________________________________________________________________________ summary _________________________________________________________________________________________________
  docs: commands succeeded
  congratulations :)
```