### PR TITLE
add codecov integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,10 @@ SageMaker Experiments Python SDK
     :target: https://pypi.python.org/pypi/sagemaker-experiments
     :alt: PyPI - Downloads
 
+.. image:: https://codecov.io/gh/aws/sagemaker-experiments/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/aws/sagemaker-experiments
+   :alt: CodeCov
+
 .. image:: https://img.shields.io/pypi/status/sagemaker-experiments
     :target: https://github.com/aws/sagemaker-experiments
     :alt: PyPI - Status

--- a/src/smexperiments/api_types.py
+++ b/src/smexperiments/api_types.py
@@ -84,7 +84,7 @@ class TrialComponentParameterValue(_base_types.ApiObject):
             return self.string_value
         if self.number_value is not None:
             return str(self.number_value)
-        return ''
+        return ""
 
 
 class TrialComponentParameters(_base_types.ApiObject):

--- a/tests/unit/test_api_types.py
+++ b/tests/unit/test_api_types.py
@@ -2,11 +2,11 @@ from smexperiments import api_types
 
 
 def test_parameter_str_string():
-    param = api_types.TrialComponentParameterValue('kmeans', None)
+    param = api_types.TrialComponentParameterValue("kmeans", None)
 
     param_str = str(param)
 
-    assert 'kmeans' == param_str
+    assert "kmeans" == param_str
 
 
 def test_parameter_str_number():
@@ -14,7 +14,7 @@ def test_parameter_str_number():
 
     param_str = str(param)
 
-    assert '2.99792458' == param_str
+    assert "2.99792458" == param_str
 
 
 def test_parameter_str_none():
@@ -22,4 +22,4 @@ def test_parameter_str_none():
 
     param_str = str(param)
 
-    assert '' == param_str
+    assert "" == param_str

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37},flake8,black-format,black-check
+envlist = py{35,36,37},flake8,black-format,black-check,pylint
 
 skip_missing_interpreters = False
 ignore_basepython_conflict = True
@@ -43,18 +43,21 @@ require-code = True
 
 [testenv]
 passenv =
+    TOXENV
     AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY
     AWS_SESSION_TOKEN
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
     AWS_DEFAULT_REGION
     SAGEMAKER_ENDPOINT
+    CODECOV_UPLOAD_TOKEN
 
 # {posargs} can be passed in by additional arguments specified when invoking tox.
 # Can be used to specify which tests to run, e.g.: tox -- -s
 commands =
     coverage run --source smexperiments -m pytest {posargs} -m "not slow"
-    {env:IGNORE_COVERAGE:} coverage report  --fail-under=80
+    {env:IGNORE_COVERAGE:} coverage report  --fail-under=95
+    codecov -e TOXENV -t {env:CODECOV_UPLOAD_TOKEN:}
 extras = test
 deps =
     boto3 >= 1.10.32
@@ -62,6 +65,7 @@ deps =
     pytest
     pytest-cov
     docker
+    codecov
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION
add codecov integration to visualize code coverage

example from fork: https://codecov.io/gh/danabens/sagemaker-experiments

similar to what main python sdk has: https://codecov.io/gh/aws/sagemaker-python-sdk