### PR TITLE
add __str__ method to TrialComponentParameterValue type

### DIFF
--- a/src/smexperiments/api_types.py
+++ b/src/smexperiments/api_types.py
@@ -79,6 +79,13 @@ class TrialComponentParameterValue(_base_types.ApiObject):
             string_value=string_value, number_value=number_value, **kwargs
         )
 
+    def __str__(self):
+        if self.string_value is not None:
+            return self.string_value
+        if self.number_value is not None:
+            return str(self.number_value)
+        return ''
+
 
 class TrialComponentParameters(_base_types.ApiObject):
     @classmethod

--- a/tests/unit/test_api_types.py
+++ b/tests/unit/test_api_types.py
@@ -1,0 +1,25 @@
+from smexperiments import api_types
+
+
+def test_parameter_str_string():
+    param = api_types.TrialComponentParameterValue('kmeans', None)
+
+    param_str = str(param)
+
+    assert 'kmeans' == param_str
+
+
+def test_parameter_str_number():
+    param = api_types.TrialComponentParameterValue(None, 2.99792458)
+
+    param_str = str(param)
+
+    assert '2.99792458' == param_str
+
+
+def test_parameter_str_none():
+    param = api_types.TrialComponentParameterValue(None, None)
+
+    param_str = str(param)
+
+    assert '' == param_str


### PR DESCRIPTION
add __str__ method to TrialComponentParameterValue type

```
============================================================================================ 88 passed in 1.49s ============================================================================================
py36 run-test: commands[1] | coverage report --fail-under=80
Name                                                                     Stmts   Miss  Cover
--------------------------------------------------------------------------------------------
.tox/py36/lib/python3.6/site-packages/smexperiments/__init__.py              2      0   100%
.tox/py36/lib/python3.6/site-packages/smexperiments/_base_types.py          69      4    94%
.tox/py36/lib/python3.6/site-packages/smexperiments/_boto_functions.py      34      0   100%
.tox/py36/lib/python3.6/site-packages/smexperiments/_environment.py         36      1    97%
.tox/py36/lib/python3.6/site-packages/smexperiments/_utils.py               38      2    95%
.tox/py36/lib/python3.6/site-packages/smexperiments/api_types.py            97      7    93%
.tox/py36/lib/python3.6/site-packages/smexperiments/experiment.py           30      0   100%
.tox/py36/lib/python3.6/site-packages/smexperiments/metrics.py              77      4    95%
.tox/py36/lib/python3.6/site-packages/smexperiments/tracker.py             110     12    89%
.tox/py36/lib/python3.6/site-packages/smexperiments/trial.py                47      4    91%
.tox/py36/lib/python3.6/site-packages/smexperiments/trial_component.py      41      0   100%
--------------------------------------------------------------------------------------------
TOTAL                                                                      581     34    94%
_________________________________________________________________________________________________ summary __________________________________________________________________________________________________
  py36: commands succeeded
  congratulations :)
```