### PR TITLE
fix codecov upload

### DIFF
--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -62,11 +62,9 @@ jobs:
           IGNORE_COVERAGE: '-'
       - name: Upload Code Coverage
         if: github.event_name == 'release'
-        run: |
-          coverage combine .coverage*
-          codecov -t {env:CODECOV_UPLOAD_TOKEN}
+        run: tox -e upload-coverage
         env:
-          CODECOV_UPLOAD_TOKEN: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          CODECOV_UPLOAD_TOKEN: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
 
   release:
     needs: [test, lint]

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,6 @@ require-code = True
 passenv =
     AWS_*
     SAGEMAKER_ENDPOINT
-    CODECOV_UPLOAD_TOKEN
     COVERAGE_FILE
 # {posargs} can be passed in by additional arguments specified when invoking tox.
 # Can be used to specify which tests to run, e.g.: tox -- -s
@@ -59,7 +58,6 @@ deps =
     pytest
     pytest-cov
     docker
-    codecov
 
 [testenv:flake8]
 basepython = python3
@@ -128,3 +126,12 @@ deps =
     PyGithub
     pathlib
 commands = python scripts/release.py {posargs}
+
+[testenv:upload-coverage]
+basepython = python3
+deps =
+    codecov
+passenv =
+    CODECOV_UPLOAD_TOKEN
+commands =
+    codecov -t {env:CODECOV_UPLOAD_TOKEN:}


### PR DESCRIPTION
fix codecov upload

```
 tox -e upload-coverage
GLOB sdist-make: /Users/danabens/workplace/github/sagemaker-experiments/setup.py
upload-coverage recreate: /Users/danabens/workplace/github/sagemaker-experiments/.tox/upload-coverage
upload-coverage installdeps: codecov
upload-coverage inst: /Users/danabens/workplace/github/sagemaker-experiments/.tox/.tmp/package/1/sagemaker-experiments-0.1.6.dev0+gbc19b25.d20200131.zip
upload-coverage installed: apipkg==1.5,atomicwrites==1.3.0,attrs==19.3.0,boto3==1.11.9,botocore==1.14.9,certifi==2019.11.28,chardet==3.0.4,codecov==2.0.15,coverage==5.0.3,docker==4.1.0,docutils==0.15.2,entrypoints==0.3,execnet==1.7.1,filelock==3.0.12,flake8==3.7.9,idna==2.8,importlib-metadata==0.23,jmespath==0.9.4,mccabe==0.6.1,more-itertools==8.2.0,packaging==20.1,pluggy==0.13.1,py==1.8.1,pycodestyle==2.5.0,pyflakes==2.1.1,pyparsing==2.4.6,pytest==4.4.1,pytest-cov==2.8.1,pytest-cover==3.0.0,pytest-coverage==0.0,pytest-forked==1.1.3,pytest-rerunfailures==8.0,pytest-xdist==1.31.0,python-dateutil==2.8.1,requests==2.22.0,s3transfer==0.3.2,sagemaker-experiments==0.1.6.dev0+gbc19b25.d20200131,six==1.14.0,toml==0.10.0,tox==3.13.1,urllib3==1.25.8,virtualenv==16.7.9,websocket-client==0.57.0,zipp==2.1.0
upload-coverage run-test-pre: PYTHONHASHSEED='3576457451'
fix codecov upload
upload-coverage run-test: commands[0] | codecov -t REDACTED

      _____          _
     / ____|        | |
    | |     ___   __| | ___  ___ _____   __
    | |    / _ \ / _  |/ _ \/ __/ _ \ \ / /
    | |___| (_) | (_| |  __/ (_| (_) \ V /
     \_____\___/ \____|\___|\___\___/ \_/
                                    v2.0.15

==> Detecting CI provider
  -> Got branch from git/hg
  -> Got sha from git/hg
==> Preparing upload
==> Processing gcov (disable by -X gcov)
    Executing gcov (find /Users/danabens/workplace/github/sagemaker-experiments -not -path './bower_components/**' -not -path './node_modules/**' -not -path './vendor/**' -type f -name '*.gcno'  -exec gcov -pb  {} +)
==> Collecting reports
    + /Users/danabens/workplace/github/sagemaker-experiments/coverage.xml bytes=23761
==> Uploading
    .url https://codecov.io
    .query commit=bc19b2542aea8b7b0b53d64548fee7408bb48f3f&branch=codecov-fix&token=<secret>&package=py2.0.15
    Pinging Codecov...
    Uploading to S3...
    https://codecov.io/github/danabens/sagemaker-experiments/commit/bc19b2542aea8b7b0b53d64548fee7408bb48f3f
________________________________________________________________________________________________ summary _________________________________________________________________________________________________
  upload-coverage: commands succeeded
  congratulations :)
```