### PR TITLE
fix. Add default sagemaker_boto_client to list classmethods.

### DIFF
--- a/src/smexperiments/_base_types.py
+++ b/src/smexperiments/_base_types.py
@@ -102,6 +102,7 @@ class Record(ApiObject):
         sagemaker_boto_client=None,
         **kwargs
     ):
+        sagemaker_boto_client = sagemaker_boto_client or _utils.sagemaker_client()
         next_token = None
         while True:
             list_request_kwargs = _boto_functions.to_boto(kwargs, cls._custom_boto_names, cls._custom_boto_types)

--- a/tests/unit/test_base_types.py
+++ b/tests/unit/test_base_types.py
@@ -150,3 +150,11 @@ def test_list_with_next_token(sagemaker_boto_client):
             "list", DummyRecordSummary.from_boto, "TestRecordSummaries", sagemaker_boto_client=sagemaker_boto_client,
         )
     )
+
+
+@unittest.mock.patch('smexperiments._base_types._utils.sagemaker_client')
+def test_list_no_client(mocked_utils_sagemaker_client, sagemaker_boto_client):
+    mocked_utils_sagemaker_client.return_value = sagemaker_boto_client
+    sagemaker_boto_client.list.side_effect = []
+    list(DummyRecord._list("list", DummyRecordSummary.from_boto, "TestRecordSummaries"))
+    _base_types._utils.sagemaker_client.assert_called()


### PR DESCRIPTION

*Description of changes:* Add default sagemaker_boto_client to list classmethods

*Testing done:* New unit test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/master/CONTRIBUTING.md) doc
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/master/CONTRIBUTING.md#committing-your-change)
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-experiments/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-experiments/tree/master/doc) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.