### PR TITLE
pull latest tag after creating release

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -38,27 +38,42 @@ def get_version_increment_type(last_version):
     return parsed_subjects.increment_type()
 
 
-def release():
-    """Creates a github release."""
+def pull_latest_and_verify(expected_version_tag):
+    check_output(["git", "pull"])
+    latest_version = get_current_version()
+    if latest_version != expected_version_tag:
+        raise ValueError(f"Expected {expected_version_tag} to be latest tag, but was {latest_version}")
 
+
+def get_current_version():
     # get the last release tag
     stdout = check_output(["git", "describe", "--abbrev=0", "--tags"])
     stdout = stdout.decode("utf-8")
     last_version = stdout.strip()
+    return last_version
 
-    if not recent_changes_to_src(last_version):
+
+def release():
+    """Creates a github release."""
+    latest_version = get_current_version()
+    print(f"Current version is {latest_version}")
+
+    if not recent_changes_to_src(latest_version):
         print("Nothing to release.")
         exit(1)
         return
 
-    changes = get_changes(last_version)
+    changes = get_changes(latest_version)
 
-    increment_type = get_version_increment_type(last_version)
+    increment_type = get_version_increment_type(latest_version)
 
-    next_version = get_next_version(last_version, increment_type)
+    next_version = get_next_version(latest_version, increment_type)
 
-    manager = ReleaseManager(str(next_version), changes)
-    manager.create_release()
+    manager = ReleaseManager(next_version, changes)
+    tag_created = manager.create_release()
+
+    # pull the new tag that was just created
+    pull_latest_and_verify(tag_created)
 
 
 def main():

--- a/scripts/release_manager.py
+++ b/scripts/release_manager.py
@@ -23,3 +23,4 @@ class ReleaseManager:
         repo.create_git_release(tag=tag, name=name, message=message, draft=False, prerelease=False)
         print(f"Created release {name}")
         print(f"See it at https://github.com/{self._repo}/releases")
+        return tag


### PR DESCRIPTION
after creating the release pull to local repo so subsequent workflow steps have the newly created tag