### PR TITLE
feature - create metrics writer in Tracker.create path

### DIFF
--- a/src/smexperiments/tracker.py
+++ b/src/smexperiments/tracker.py
@@ -115,6 +115,7 @@ class Tracker(object):
         else:
             raise ValueError('Could not load TrialComponent. Specify a trial_component_name or invoke "create"')
 
+        # if running in a SageMaker context write metrics to file
         if not trial_component_name and tce.environment_type == _environment.EnvironmentType.SageMakerTrainingJob:
             metrics_writer = metrics.SageMakerFileMetricsWriter()
         else:
@@ -160,8 +161,13 @@ class Tracker(object):
             display_name=display_name,
             sagemaker_boto_client=sagemaker_boto_client,
         )
+
+        metrics_writer = metrics.SageMakerFileMetricsWriter()
+
         return cls(
-            tc, None, _ArtifactUploader(tc.trial_component_name, artifact_bucket, artifact_prefix, boto3_session)
+            tc,
+            metrics_writer,
+            _ArtifactUploader(tc.trial_component_name, artifact_bucket, artifact_prefix, boto3_session),
         )
 
     def log_parameter(self, name, value):

--- a/tests/unit/test_tracker.py
+++ b/tests/unit/test_tracker.py
@@ -117,6 +117,23 @@ def test_load(boto3_session, sagemaker_boto_client):
     )
 
 
+def test_create(boto3_session, sagemaker_boto_client):
+    trial_component_name = "foo-trial-component"
+    trial_component_display_name = "foo-trial-component-display-name"
+    sagemaker_boto_client.create_trial_component.return_value = {"TrialComponentName": trial_component_name}
+    tracker_created = tracker.Tracker.create(
+        display_name=trial_component_display_name, sagemaker_boto_client=sagemaker_boto_client
+    )
+    assert trial_component_name == tracker_created.trial_component.trial_component_name
+
+    assert tracker_created._metrics_writer is not None
+
+    tracker_created._metrics_writer = unittest.mock.Mock()
+    now = datetime.datetime.now()
+    tracker_created.log_metric("foo", 1.0, 1, now)
+    tracker_created._metrics_writer.log_metric.assert_called_with("foo", 1.0, 1, now)
+
+
 @pytest.fixture
 def trial_component_obj(sagemaker_boto_client):
     return trial_component.TrialComponent(sagemaker_boto_client)


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/sagemaker-experiments/issues/60

*Description of changes:*

Added metrics writer creation in Tracker.create path.  Since the metric writer is only writing to file (not an API) there is no reason to limit its use to only ```load``` or in a SageMaker context. Ideally, the only difference between load and create should be where the trial component is retrieved from.

*Testing done:*

unit tests

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-experiments/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-experiments/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.