### PR TITLE
fix: don't log an error during expected exception in metrics file writer

### DIFF
--- a/src/smexperiments/metrics.py
+++ b/src/smexperiments/metrics.py
@@ -52,8 +52,7 @@ class SageMakerFileMetricsWriter(object):
             logging.debug("Writing metric: %s", raw_metric_data)
             self._file.write(json.dumps(raw_metric_data.to_record()))
             self._file.write("\n")
-        except AttributeError as e:
-            logging.error(e)
+        except AttributeError:
             if self._closed:
                 raise SageMakerMetricsWriterException("log_metric called on a closed writer")
             elif not self._file:
@@ -84,7 +83,9 @@ class SageMakerFileMetricsWriter(object):
 
     def _get_metrics_file_path(self):
         pid_filename = "{}.json".format(str(os.getpid()))
-        return self._metrics_file_path or os.path.join(METRICS_DIR, pid_filename)
+        metrics_file_path = self._metrics_file_path or os.path.join(METRICS_DIR, pid_filename)
+        logging.debug("metrics_file_path=" + metrics_file_path)
+        return metrics_file_path
 
 
 class SageMakerMetricsWriterException(Exception):


### PR DESCRIPTION
We initialize the metrics file writer by lazy initializing a file handle after an initial ```AttributeError``` occurs on the first attempt to log_metric. However the first thing within the ```try``` block was a ```logging.error``` statement which surfaced the exception to the notebook user (causing confusion) even though we expected it and handled it successfully. Removed the error log as we are either raising or handling all exceptions so there is no reason for the error log.

### Testing Done
Created a test notebook, loaded modified SDK files, verified error is not logged and metrics are written to file as expected.

There are no other similar error log statements in the repo.