### PR TITLE
remove auto generated aws tag in integ test. fix delete_all exception

### DIFF
--- a/src/smexperiments/experiment.py
+++ b/src/smexperiments/experiment.py
@@ -244,10 +244,10 @@ class Experiment(_base_types.Record):
             )
 
         delete_count = 0
-        last_exception_message = None
+        last_exception = None
         while True:
             if delete_count == 3:
-                raise Exception("Fail to delete because" + last_exception_message + ", please try again.")
+                raise Exception("Fail to delete, please try again.") from last_exception
             try:
                 for trial_summary in self.list_trials():
                     t = trial.Trial.load(
@@ -266,6 +266,6 @@ class Experiment(_base_types.Record):
                 self.delete()
                 break
             except Exception as ex:
-                last_exception_message = ex
+                last_exception = ex
             finally:
                 delete_count = delete_count + 1

--- a/tests/integ/test_experiment.py
+++ b/tests/integ/test_experiment.py
@@ -28,6 +28,9 @@ def test_create_tags(experiment_obj, sagemaker_boto_client):
         actual_tags = sagemaker_boto_client.list_tags(ResourceArn=experiment_obj.experiment_arn)["Tags"]
         if actual_tags:
             break
+    for tag in actual_tags:
+        if "aws:tag" in tag.get("Key"):
+            actual_tags.remove(tag)
     assert actual_tags == experiment_obj.tags
 
 
@@ -133,5 +136,5 @@ def test_delete_all(complex_experiment_obj):
 
 
 def test_delete_all_fails(experiment_obj):
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         experiment_obj.delete_all(action="test")

--- a/tests/integ/test_trial.py
+++ b/tests/integ/test_trial.py
@@ -27,6 +27,9 @@ def test_create_tags(trial_obj, sagemaker_boto_client):
         actual_tags = sagemaker_boto_client.list_tags(ResourceArn=trial_obj.trial_arn)["Tags"]
         if actual_tags:
             break
+    for tag in actual_tags:
+        if "aws:tag" in tag.get("Key"):
+            actual_tags.remove(tag)
     assert actual_tags == trial_obj.tags
 
 

--- a/tests/integ/test_trial_component.py
+++ b/tests/integ/test_trial_component.py
@@ -28,6 +28,9 @@ def test_create_tags(trial_component_obj, sagemaker_boto_client):
         actual_tags = sagemaker_boto_client.list_tags(ResourceArn=trial_component_obj.trial_component_arn)["Tags"]
         if actual_tags:
             break
+    for tag in actual_tags:
+        if "aws:tag" in tag.get("Key"):
+            actual_tags.remove(tag)
     assert actual_tags == trial_component_obj.tags
 
 

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -294,5 +294,6 @@ def test_delete_all(sagemaker_boto_client):
 def test_delete_all_fail(sagemaker_boto_client):
     obj = experiment.Experiment(sagemaker_boto_client, experiment_name="foo", description="bar")
     sagemaker_boto_client.list_trials.side_effect = Exception
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as e:
         obj.delete_all(action="--force")
+    assert str(e.value) == "Fail to delete, please try again."


### PR DESCRIPTION
1.remove auto generated aws tag in integ test.
2. fix delete_all exception message. 
based on https://stackoverflow.com/questions/1483429/how-to-print-an-exception-in-python, we need to add str() around exception for python 2.5 and earlier. 
