### PR TITLE
fix metric buffer not flushing on newline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ var/
 .installed.cfg
 *.egg
 *.gz
+.eggs
 
 # Installer logs
 pip-log.txt

--- a/src/smexperiments/metrics.py
+++ b/src/smexperiments/metrics.py
@@ -56,7 +56,7 @@ class SageMakerFileMetricsWriter(object):
             if self._closed:
                 raise SageMakerMetricsWriterException("log_metric called on a closed writer")
             elif not self._file:
-                self._file = open(self._get_metrics_file_path(), "a")
+                self._file = open(self._get_metrics_file_path(), "a", buffering=1)
                 self._file.write(json.dumps(raw_metric_data.to_record()))
                 self._file.write("\n")
             else:

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -111,6 +111,31 @@ def test_file_metrics_writer_log_metric(timestamp, filepath):
     assert 2 == entry_four["IterationNumber"]
 
 
+def test_file_metrics_writer_flushes_buffer_every_line_log_metric(filepath):
+    writer = metrics.SageMakerFileMetricsWriter(filepath)
+
+    writer.log_metric(metric_name="foo", value=1.0)
+
+    lines = [x for x in open(filepath).read().split("\n") if x]
+    [entry_one] = [json.loads(line) for line in lines]
+    assert "foo" == entry_one["MetricName"]
+    assert 1.0 == entry_one["Value"]
+
+    writer.log_metric(metric_name="bar", value=2.0)
+    lines = [x for x in open(filepath).read().split("\n") if x]
+    [entry_one, entry_two] = [json.loads(line) for line in lines]
+    assert "bar" == entry_two["MetricName"]
+    assert 2.0 == entry_two["Value"]
+
+    writer.log_metric(metric_name="biz", value=3.0)
+    lines = [x for x in open(filepath).read().split("\n") if x]
+    [entry_one, entry_two, entry_three] = [json.loads(line) for line in lines]
+    assert "biz" == entry_three["MetricName"]
+    assert 3.0 == entry_three["Value"]
+
+    writer.close()
+
+
 def test_file_metrics_writer_context_manager(timestamp, filepath):
     with metrics.SageMakerFileMetricsWriter(filepath) as writer:
         writer.log_metric("foo", value=1.0, timestamp=timestamp)


### PR DESCRIPTION
log_metric was using binary based buffering that flushed to file after a certain number of bytes were written (~60 lines) instead of new line buffering.

https://docs.python.org/3/library/functions.html#open