### PR TITLE
fix: integration test throttling of AssociationTrialComponent

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,7 @@ def complex_experiment_obj(sagemaker_boto_client):
         sagemaker_boto_client.associate_trial_component(
             TrialName=trial_obj.trial_name, TrialComponentName=trial_component_obj.trial_component_name
         )
+        time.sleep(0.5)
     time.sleep(1.0)
     yield experiment_obj
     experiment_obj.delete_all(action="--force")


### PR DESCRIPTION
fix occasional throttling exception and black format

>        # associate the trials with trial components
>        for trial_obj in trial_objs:
>            sagemaker_boto_client.associate_trial_component(
>               TrialName=trial_obj.trial_name, TrialComponentName=trial_component_obj.trial_component_name
>           )
> botocore.exceptions.ClientError: An error occurred (ThrottlingException) when calling the AssociateTrialComponent operation (reached max retries: 4): Rate exceeded