### PR TITLE
add documentation regarding limitations of log_metric method

### DIFF
--- a/tests/unit/test_tracker.py
+++ b/tests/unit/test_tracker.py
@@ -151,12 +151,7 @@ def test_create(boto3_session, sagemaker_boto_client):
     )
     assert trial_component_name == tracker_created.trial_component.trial_component_name
 
-    assert tracker_created._metrics_writer is not None
-
-    tracker_created._metrics_writer = unittest.mock.Mock()
-    now = datetime.datetime.now()
-    tracker_created.log_metric("foo", 1.0, 1, now)
-    tracker_created._metrics_writer.log_metric.assert_called_with("foo", 1.0, 1, now)
+    assert tracker_created._metrics_writer is None
 
 
 @pytest.fixture


### PR DESCRIPTION
Add documentation on `log_metric` limitations due to how it works: sdk writes metrics to file and metrics agent parses metrics in file and adds to SM, if the metrics agent isn't present then metrics won't show up in SM.