### PR TITLE
Fix to parameter validation of `tracker.log_table`

### DIFF
--- a/src/smexperiments/tracker.py
+++ b/src/smexperiments/tracker.py
@@ -450,7 +450,7 @@ class Tracker(object):
                         'Table values should be list. i.e. {"x": [1,2,3]}, instead was ' + str(type(values[key]))
                     )
 
-        if data_frame:
+        if data_frame is not None:
             values = _ArtifactConverter.convert_data_frame_to_values(data_frame)
             fields = _ArtifactConverter.convert_data_frame_to_fields(data_frame)
         else:

--- a/tests/unit/test_tracker.py
+++ b/tests/unit/test_tracker.py
@@ -588,6 +588,27 @@ def test_log_table(under_test):
     under_test._lineage_artifact_tracker.add_input_artifact("TestTable", "s3uri_value", "etag_value", "Table")
 
 
+def test_log_table_dataframe(under_test):
+
+    dataframe = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+
+    under_test._artifact_uploader.upload_object_artifact.return_value = ("s3uri_value", "etag_value")
+
+    under_test.log_table(title="TestTable", data_frame=dataframe)
+    expected_data = {
+        "type": "Table",
+        "version": 0,
+        "title": "TestTable",
+        "fields": [{"name": "x", "type": "number"}, {"name": "y", "type": "number"}],
+        "data": {"x": [1, 2, 3], "y": [4, 5, 6]},
+    }
+    under_test._artifact_uploader.upload_object_artifact.assert_called_with(
+        "TestTable", expected_data, file_extension="json"
+    )
+
+    under_test._lineage_artifact_tracker.add_input_artifact("TestTable", "s3uri_value", "etag_value", "Table")
+
+
 def test_log_roc_curve(under_test):
     y_true = [0, 0, 1, 1]
     y_scores = [0.1, 0.4, 0.35, 0.8]


### PR DESCRIPTION
…ssed

*Issue #, if available:*
NA

*Description of changes:*
Changed parameter validation for dataframe to `if dataframe is not None:`. Current `if dataframe:` causes the `index of an array is ambiguous...etc` error which was preventing using it to log dfs. 

*Testing done:*
Added a simple dataframe test. Let me know if more are needed.  The `.to_dict()` method in the conversion should catch most things that aren't dataframes. Maybe consider `isinstance`ing and raising as well? Happy to add it. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md) doc
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md#committing-your-change)
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-experiments/blob/main/README.rst) and [API docs](https://github.com/aws/sagemaker-experiments/tree/main/doc) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.