### PR TITLE
remove unneccessary codcov token

### DIFF
--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -66,8 +66,6 @@ jobs:
       - name: Upload Code Coverage
         if: github.event_name == 'schedule'
         run: tox -e upload-coverage
-        env:
-          CODECOV_UPLOAD_TOKEN: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
 
   release:
     needs: [test, lint]

--- a/tox.ini
+++ b/tox.ini
@@ -142,10 +142,9 @@ commands = python scripts/release.py {posargs}
 basepython = python3
 deps =
     codecov
-passenv =
-    CODECOV_UPLOAD_TOKEN
+# Token not required public repos uploading from GH Actions.
 commands =
-    codecov -t {env:CODECOV_UPLOAD_TOKEN:}
+    codecov
     
 [testenv:docstyle]
 deps = pydocstyle


### PR DESCRIPTION
remove unnecessary codecov token

From settings page:
> Note: Token not required for public repositories uploading from Travis, CircleCI, AppVeyor, Azure Pipelines or GitHub Actions.