### PR TITLE
Revert "remove unneccessary codcov token"

### DIFF
--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Upload Code Coverage
         if: github.event_name == 'schedule'
         run: tox -e upload-coverage
+        env:
+          CODECOV_UPLOAD_TOKEN: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
 
   release:
     needs: [test, lint]

--- a/tox.ini
+++ b/tox.ini
@@ -142,9 +142,10 @@ commands = python scripts/release.py {posargs}
 basepython = python3
 deps =
     codecov
-# Token not required public repos uploading from GH Actions.
+passenv =
+    CODECOV_UPLOAD_TOKEN
 commands =
-    codecov
+    codecov -t {env:CODECOV_UPLOAD_TOKEN:}
     
 [testenv:docstyle]
 deps = pydocstyle


### PR DESCRIPTION
This wasn't actually necessary  or correct - just needed to rotate codecov token and mis-interpreted instructions on codecov settings page ("no-token-needed" only applies when using the official codecov GH action, not when running codecov generically via tox).