### PR TITLE
clarify log_metric behavior in Tracker documentation

### DIFF
--- a/src/smexperiments/tracker.py
+++ b/src/smexperiments/tracker.py
@@ -48,7 +48,10 @@ class Tracker(object):
     end times are automatically set when using the with statement and the trial component is saved to
     SageMaker at the end of the block.
 
-    Note that only parameters, input artifacts, and output artifacts are saved to SageMaker. Metrics are saved to file.
+    Note that parameters and input/output artifacts are saved to SageMaker directly via the
+    UpdateTrialComponent operation. In contrast metrics (via `log_metric` method) are saved to a file, which is
+    then ingested into SageMaker via a metrics agent _which only runs on training job hosts_. As a result any metrics
+    logged in non-training job host environments will not be ingested into SageMaker.
 
     Attributes:
         trial_component (TrialComponent): The trial component tracked.


### PR DESCRIPTION
Tracker has some confusing behavior around metrics and documentation needs to be updated to reflect it.