### PR TITLE
Fix MNIST data location, add os import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Examples
 .. code-block:: python
 
     import boto3
-    import pickle, gzip, numpy, urllib.request, json
+    import pickle, gzip, numpy, json, os
     import io
     import numpy as np
     import sagemaker.amazon.common as smac
@@ -123,7 +123,8 @@ Examples
     container = get_image_uri(boto3.Session().region_name, 'linear-learner')
 
     # Load the dataset
-    urllib.request.urlretrieve("http://deeplearning.net/data/mnist/mnist.pkl.gz", "mnist.pkl.gz")
+    s3 = boto3.client("s3")
+    s3.download_file("sagemaker-sample-files", "datasets/image/MNIST/mnist.pkl.gz", "mnist.pkl.gz")
     with gzip.open('mnist.pkl.gz', 'rb') as f:
         train_set, valid_set, test_set = pickle.load(f, encoding='latin1')
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-sagemaker-examples/issues/2876

*Description of changes:* Download MNIST dataset from AWS-hosted bucket, instead of from broken third-party URL. Add missing os package import.

*Testing done:* Ran code snippet in SageMaker notebook instance.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md#committing-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-experiments/blob/main/README.rst) and [API docs](https://github.com/aws/sagemaker-experiments/tree/main/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.