### PR TITLE
generate docs during CI

### DIFF
--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -29,6 +29,8 @@ jobs:
         run: tox -e pylint
       - name: Docstyle
         run: tox -e docstyle
+      - name: Doc Generation
+        run: tox -e docs
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will ensure the build will fail docs fail to generate.