### PR TITLE
doc: view ROC, PR, and confusion matrix in Trial Component UI

### DIFF
--- a/src/smexperiments/tracker.py
+++ b/src/smexperiments/tracker.py
@@ -471,9 +471,9 @@ class Tracker(object):
         output_artifact=True,
         no_skill=None,
     ):
-        """Log a precision recall graph artifact. If your job is created by a pipeline
-        execution you can view the artifact by selecting the corresponding step in the pipelines UI.
-        The Trial Component UI currently does not support rendering of the artifact.
+        """Log a precision recall graph artifact. You can view the artifact in the charts tab of the
+        Trial Component UI. If your job is created by a pipeline execution you can view the artifact
+        by selecting the corresponding step in the pipelines UI.
         See also `SageMaker Pipelines <https://aws.amazon.com/sagemaker/pipelines/>`_
 
         Requires sklearn.
@@ -535,9 +535,9 @@ class Tracker(object):
         title=None,
         output_artifact=True,
     ):
-        """Log a receiver operating characteristic (ROC curve) artifact. If your job is created by a pipeline
-        execution you can view the artifact by selecting the corresponding step in the pipelines UI.
-        The Trial Component UI currently does not support rendering of the artifact.
+        """Log a receiver operating characteristic (ROC curve) artifact. You can view the artifact
+        in the charts tab of the Trial Component UI. If your job is created by a pipeline execution
+        you can view the artifact by selecting the corresponding step in the pipelines UI.
         See also `SageMaker Pipelines <https://aws.amazon.com/sagemaker/pipelines/>`_
 
         Requires sklearn.
@@ -588,9 +588,9 @@ class Tracker(object):
         title=None,
         output_artifact=True,
     ):
-        """Log a confusion matrix artifact. If your job is created by a pipeline execution you can view the
-        artifact by selecting the corresponding step in the pipelines UI. The Trial Component UI
-        currently does not support rendering of the artifact.
+        """Log a confusion matrix artifact. You can view the artifact in the charts tab of the
+        Trial Component UI. If your job is created by a pipeline execution you can view the
+        artifact by selecting the corresponding step in the pipelines UI.
         See also `SageMaker Pipelines <https://aws.amazon.com/sagemaker/pipelines/>`_
 
         Requires sklearn.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* update documentation for three tracker apis (log_precision_recall, log_roc_curve, log_confusion_matrix) to show that their artifacts can be viewed in the Trial Component UI

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md#committing-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-experiments/blob/main/README.rst) and [API docs](https://github.com/aws/sagemaker-experiments/tree/main/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.