### PR TITLE
change name suffix resolution to account for sub-second api calls

### DIFF
--- a/src/smexperiments/_utils.py
+++ b/src/smexperiments/_utils.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import os
 import random
-import time
+from datetime import datetime
 
 import boto3
 import botocore
@@ -44,7 +44,7 @@ def boto_session():
 def suffix():
     """Generate a random string of length 4"""
     alph = "abcdefghijklmnopqrstuvwxyz"
-    return "-".join([time.strftime("%Y-%m-%d-%H%M%S"), "".join(random.sample(alph, 4))])
+    return "-".join([datetime.utcnow().strftime("%Y-%m-%d-%H%M%S%f"), "".join(random.sample(alph, 4))])
 
 
 def name(prefix):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Increase the length of the suffix for auto-generated entities by increasing the time resolution from seconds to microseconds (adding 6 characters to the suffix).

*Testing done:* Unit tests.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md) doc
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md#committing-your-change)
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-experiments/blob/main/README.rst) and [API docs](https://github.com/aws/sagemaker-experiments/tree/main/doc) (if appropriate)

#### Tests

- [x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.