### PR TITLE
Parameterize trial_component_name in Tracker.py Create Function

### DIFF
--- a/src/smexperiments/tracker.py
+++ b/src/smexperiments/tracker.py
@@ -167,6 +167,7 @@ class Tracker(object):
     @classmethod
     def create(
         cls,
+        trial_component_name="TrialComponent",
         display_name=None,
         artifact_bucket=None,
         artifact_prefix=None,
@@ -185,6 +186,7 @@ class Tracker(object):
                 my_tracker = tracker.Tracker.create()
 
         Args:
+            trial_component_name: (str,optional). The name of the trial component resource. Defaults to "TrialComponent".
             display_name: (str, optional). The display name of the trial component to track.
             artifact_bucket: (str, optional) The name of the S3 bucket to store artifacts to.
             artifact_prefix: (str, optional) The prefix to write artifacts to within ``artifact_bucket``
@@ -201,7 +203,7 @@ class Tracker(object):
         sagemaker_boto_client = sagemaker_boto_client or _utils.sagemaker_client()
 
         tc = trial_component.TrialComponent.create(
-            trial_component_name=_utils.name("TrialComponent"),
+            trial_component_name=_utils.name(trial_component_name),
             display_name=display_name,
             sagemaker_boto_client=sagemaker_boto_client,
         )

--- a/tests/unit/test_tracker.py
+++ b/tests/unit/test_tracker.py
@@ -149,11 +149,20 @@ def test_create(boto3_session, sagemaker_boto_client):
     trial_component_display_name = "foo-trial-component-display-name"
     sagemaker_boto_client.create_trial_component.return_value = {"TrialComponentName": trial_component_name}
     tracker_created = tracker.Tracker.create(
-        display_name=trial_component_display_name, sagemaker_boto_client=sagemaker_boto_client
+        trial_component_name="AlexName",
+        display_name=trial_component_display_name,
+        sagemaker_boto_client=sagemaker_boto_client,
     )
     assert trial_component_name == tracker_created.trial_component.trial_component_name
-
+    sagemaker_boto_client.create_trial_component.assert_called_with(
+        DisplayName="foo-trial-component-display-name", TrialComponentName=AnyStringWith("AlexName")
+    )
     assert tracker_created._metrics_writer is None
+
+
+class AnyStringWith(str):
+    def __eq__(self, other):
+        return self in other
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ deps =
     pytest
     pytest-cov
     docker
+    scikit-learn==0.24.2
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION
*Issue #, if available:* No Issue Created

*Description of changes:*
 
Updated the create function in the Tracker.py file. Previously, this function hardcoded the trial_component_name as "TrialComponent". This can cause issues for users calling this function that have IAM policies in place that require them give specific names to experiment-trial-component resources. I parameterized trial_component_name as a function parameter and gave it a default of "TrialComponent". This way, the change should not be breaking to anyone.

The unit test test_log_pr_curve in test_tracker.py was failing on Python 3.8 but not other versions of Python. This was because sklearn automatically upgraded to 1.1.1 in python 3.8. I fixed this by forcing all unit tests to use sklearn==0.24.2 because that's the latest version that supports python 36, 37, and 38. I updated tox.ini to do this.


*Testing done:*

I added an additional assertion on test_create in test_tracker.py to validate the new trial_component_name parameter on Tracker.create.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md#committing-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-experiments/blob/main/README.rst) and [API docs](https://github.com/aws/sagemaker-experiments/tree/main/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.