### PR TITLE
[fix] Update deprecated sklearn dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
             "pytest-xdist",
             "docker",
             "pandas",
-            "sklearn",
+            "scikit-learn",
         ]
     },
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changing the `sklearn` dep to `scikit-learn` following the advisory published at https://github.com/scikit-learn/sklearn-pypi-package.

*Testing done:*

Unit tests for Python3.7 and Python 3.8.

```
tox tests/unit                                                             ~/workplace/sagemaker-experiments
GLOB sdist-make: /workplace/ksiman/sagemaker-experiments/setup.py
py36 create: /workplace/ksiman/sagemaker-experiments/.tox/py36
ERROR: InterpreterNotFound: python3.6
py37 create: /workplace/ksiman/sagemaker-experiments/.tox/py37
py37 installdeps: boto3 >= 1.12.8, python-dateutil, pytest, pytest-cov, docker, scikit-learn==0.24.2
py37 inst: /workplace/ksiman/sagemaker-experiments/.tox/.tmp/package/1/sagemaker-experiments-0.1.dev140+gbca8812.zip
py37 installed: atomicwrites==1.4.1,attrs==22.1.0,boto3==1.26.22,botocore==1.29.22,certifi==2022.9.24,charset-normalizer==2.1.1,coverage==6.5.0,distlib==0.3.6,docker==6.0.1,exceptiongroup==1.0.4,execnet==1.9.0,filelock==3.8.1,flake8==5.0.3,idna==3.4,importlib-metadata==0.23,iniconfig==1.1.1,jmespath==1.0.1,joblib==1.2.0,mccabe==0.7.0,more-itertools==9.0.0,numpy==1.21.6,packaging==21.3,pandas==1.3.5,platformdirs==2.5.4,pluggy==0.13.1,py==1.11.0,pycodestyle==2.9.1,pyflakes==2.5.0,pyparsing==3.0.9,pytest==4.4.1,pytest-cov==2.9.0,pytest-cover==3.0.0,pytest-coverage==0.0,pytest-forked==1.4.0,pytest-rerunfailures==8.0,pytest-xdist==1.34.0,python-dateutil==2.8.2,pytz==2022.6,requests==2.28.1,s3transfer==0.6.0,sagemaker-experiments @ file:///workplace/ksiman/sagemaker-experiments/.tox/.tmp/package/1/sagemaker-experiments-0.1.dev140%2Bgbca8812.zip,scikit-learn==0.24.2,scipy==1.7.3,six==1.16.0,threadpoolctl==3.1.0,toml==0.10.2,tomli==2.0.1,tox==3.13.1,typing_extensions==4.4.0,urllib3==1.26.13,virtualenv==20.16.2,websocket-client==1.4.2,zipp==3.11.0
py37 run-test-pre: PYTHONHASHSEED='3242486325'
py37 run-test: commands[0] | coverage run --source smexperiments -m pytest tests/unit
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.7.15, pytest-4.4.1, py-1.11.0, pluggy-0.13.1
cachedir: .tox/py37/.pytest_cache
rootdir: /workplace/ksiman/sagemaker-experiments, inifile: pytest.ini
plugins: xdist-1.34.0, cov-2.9.0, rerunfailures-8.0, forked-1.4.0
collected 148 items

tests/unit/test_api_types.py ...                                                                                                                                 [  2%]
tests/unit/test_base_types.py ............                                                                                                                       [ 10%]
tests/unit/test_environment.py .....                                                                                                                             [ 13%]
tests/unit/test_experiment.py .................                                                                                                                  [ 25%]
tests/unit/test_list_trial_components_from_trial.py ......                                                                                                       [ 29%]
tests/unit/test_metrics.py ..........                                                                                                                            [ 35%]
tests/unit/test_search_expression.py .....                                                                                                                       [ 39%]
tests/unit/test_tracker.py .....................................................                                                                                 [ 75%]
tests/unit/test_training_job.py .                                                                                                                                [ 75%]
tests/unit/test_trial.py ...................                                                                                                                     [ 88%]
tests/unit/test_trial_component.py ............                                                                                                                  [ 96%]
tests/unit/test_utils.py .....                                                                                                                                   [100%]

===================================================================== 148 passed in 38.09 seconds ======================================================================
py37 run-test: commands[1] | coverage report --fail-under=95
Name                                                                       Stmts   Miss  Cover
----------------------------------------------------------------------------------------------
.tox/py37/lib/python3.7/site-packages/smexperiments/__init__.py                2      0   100%
.tox/py37/lib/python3.7/site-packages/smexperiments/_base_types.py            94      7    93%
.tox/py37/lib/python3.7/site-packages/smexperiments/_boto_functions.py        34      0   100%
.tox/py37/lib/python3.7/site-packages/smexperiments/_environment.py           36      1    97%
.tox/py37/lib/python3.7/site-packages/smexperiments/_utils.py                 41      2    95%
.tox/py37/lib/python3.7/site-packages/smexperiments/api_types.py             147      7    95%
.tox/py37/lib/python3.7/site-packages/smexperiments/experiment.py             58      0   100%
.tox/py37/lib/python3.7/site-packages/smexperiments/metrics.py                79      4    95%
.tox/py37/lib/python3.7/site-packages/smexperiments/search_expression.py      47      0   100%
.tox/py37/lib/python3.7/site-packages/smexperiments/tracker.py               287     24    92%
.tox/py37/lib/python3.7/site-packages/smexperiments/training_job.py            6      0   100%
.tox/py37/lib/python3.7/site-packages/smexperiments/trial.py                  75      2    97%
.tox/py37/lib/python3.7/site-packages/smexperiments/trial_component.py        63      0   100%
----------------------------------------------------------------------------------------------
TOTAL                                                                        969     47    95%
py38 create: /workplace/ksiman/sagemaker-experiments/.tox/py38
py38 installdeps: boto3 >= 1.12.8, python-dateutil, pytest, pytest-cov, docker, scikit-learn==0.24.2
py38 inst: /workplace/ksiman/sagemaker-experiments/.tox/.tmp/package/1/sagemaker-experiments-0.1.dev140+gbca8812.zip
py38 installed: atomicwrites==1.4.1,attrs==22.1.0,boto3==1.26.22,botocore==1.29.22,certifi==2022.9.24,charset-normalizer==2.1.1,coverage==6.5.0,distlib==0.3.6,docker==6.0.1,exceptiongroup==1.0.4,execnet==1.9.0,filelock==3.8.1,flake8==6.0.0,idna==3.4,importlib-metadata==0.23,iniconfig==1.1.1,jmespath==1.0.1,joblib==1.2.0,mccabe==0.7.0,more-itertools==9.0.0,numpy==1.23.5,packaging==21.3,pandas==1.5.2,platformdirs==2.5.4,pluggy==0.13.1,py==1.11.0,pycodestyle==2.10.0,pyflakes==3.0.1,pyparsing==3.0.9,pytest==4.4.1,pytest-cov==2.9.0,pytest-cover==3.0.0,pytest-coverage==0.0,pytest-forked==1.4.0,pytest-rerunfailures==8.0,pytest-xdist==1.34.0,python-dateutil==2.8.2,pytz==2022.6,requests==2.28.1,s3transfer==0.6.0,sagemaker-experiments @ file:///workplace/ksiman/sagemaker-experiments/.tox/.tmp/package/1/sagemaker-experiments-0.1.dev140%2Bgbca8812.zip,scikit-learn==0.24.2,scipy==1.9.3,six==1.16.0,threadpoolctl==3.1.0,toml==0.10.2,tomli==2.0.1,tox==3.13.1,urllib3==1.26.13,virtualenv==20.17.0,websocket-client==1.4.2,zipp==3.11.0
py38 run-test-pre: PYTHONHASHSEED='3242486325'
py38 run-test: commands[0] | coverage run --source smexperiments -m pytest tests/unit
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.8.13, pytest-4.4.1, py-1.11.0, pluggy-0.13.1
cachedir: .tox/py38/.pytest_cache
rootdir: /workplace/ksiman/sagemaker-experiments, inifile: pytest.ini
plugins: xdist-1.34.0, cov-2.9.0, rerunfailures-8.0, forked-1.4.0
collected 148 items

tests/unit/test_api_types.py ...                                                                                                                                 [  2%]
tests/unit/test_base_types.py ............                                                                                                                       [ 10%]
tests/unit/test_environment.py .....                                                                                                                             [ 13%]
tests/unit/test_experiment.py .................                                                                                                                  [ 25%]
tests/unit/test_list_trial_components_from_trial.py ......                                                                                                       [ 29%]
tests/unit/test_metrics.py ..........                                                                                                                            [ 35%]
tests/unit/test_search_expression.py .....                                                                                                                       [ 39%]
tests/unit/test_tracker.py .....................................................                                                                                 [ 75%]
tests/unit/test_training_job.py .                                                                                                                                [ 75%]
tests/unit/test_trial.py ...................                                                                                                                     [ 88%]
tests/unit/test_trial_component.py ............                                                                                                                  [ 96%]
tests/unit/test_utils.py .....                                                                                                                                   [100%]

=========================================================================== warnings summary ===========================================================================
tests/unit/test_tracker.py::test_log_pr_curve
  /workplace/ksiman/sagemaker-experiments/.tox/py38/lib/python3.8/site-packages/sklearn/utils/multiclass.py:14: DeprecationWarning: Please use `spmatrix` from the `scipy.sparse` namespace, the `scipy.sparse.base` namespace is deprecated.
    from scipy.sparse.base import spmatrix

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============================================================== 148 passed, 1 warnings in 38.22 seconds ================================================================
py38 run-test: commands[1] | coverage report --fail-under=95
Name                                                                       Stmts   Miss  Cover
----------------------------------------------------------------------------------------------
.tox/py38/lib/python3.8/site-packages/smexperiments/__init__.py                2      0   100%
.tox/py38/lib/python3.8/site-packages/smexperiments/_base_types.py            95      7    93%
.tox/py38/lib/python3.8/site-packages/smexperiments/_boto_functions.py        34      0   100%
.tox/py38/lib/python3.8/site-packages/smexperiments/_environment.py           36      1    97%
.tox/py38/lib/python3.8/site-packages/smexperiments/_utils.py                 41      2    95%
.tox/py38/lib/python3.8/site-packages/smexperiments/api_types.py             149      7    95%
.tox/py38/lib/python3.8/site-packages/smexperiments/experiment.py             57      0   100%
.tox/py38/lib/python3.8/site-packages/smexperiments/metrics.py                79      4    95%
.tox/py38/lib/python3.8/site-packages/smexperiments/search_expression.py      47      0   100%
.tox/py38/lib/python3.8/site-packages/smexperiments/tracker.py               291     24    92%
.tox/py38/lib/python3.8/site-packages/smexperiments/training_job.py            6      0   100%
.tox/py38/lib/python3.8/site-packages/smexperiments/trial.py                  75      2    97%
.tox/py38/lib/python3.8/site-packages/smexperiments/trial_component.py        63      1    98%
----------------------------------------------------------------------------------------------
TOTAL                                                                        975     48    95%
_______________________________________________________________________________ summary ________________________________________________________________________________
ERROR:  py36: InterpreterNotFound: python3.6
  py37: commands succeeded
  py38: commands succeeded
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md#committing-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-experiments/blob/main/README.rst) and [API docs](https://github.com/aws/sagemaker-experiments/tree/main/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.