### PR TITLE
upgrade action versions

### DIFF
--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -16,9 +16,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python
       - name: Install Dependencies
         run: pip install tox
       - name: Flake8
@@ -35,17 +35,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout
       - name: Setup Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python
         with:
           python-version: 3.7
       - name: Setup Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python
         with:
           python-version: 3.8
       - name: Setup Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python
         with:
           python-version: 3.9
       - name: Install Dependencies
@@ -76,9 +76,9 @@ jobs:
     if: github.event_name == 'schedule' && github.repository == 'aws/sagemaker-experiments'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python
       with:
         python-version: '3.x'
     - name: Install Dependencies

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -60,8 +60,7 @@ def release():
 
     if not recent_changes_to_src(latest_version):
         print("Nothing to release.")
-        exit(1)
-        return
+        exit(0)
 
     changes = get_changes(latest_version)
 


### PR DESCRIPTION
>Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/setup-python@v1 

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

also set exit code to 0 when nothing to release