### PR TITLE
[doc] fix log_table parameter when using DataFrame

### DIFF
--- a/src/smexperiments/tracker.py
+++ b/src/smexperiments/tracker.py
@@ -431,11 +431,11 @@ class Tracker(object):
                     "x": [1,2,3],
                     "y": [4,5,6]
                 }
-                my_tracker.log_table('SampleData',table_data)
+                my_tracker.log_table('SampleData', table_data)
 
-                # or log a data frame
+                # or log a DataFrame
                 df = pd.DataFrame(data=table_data)
-                my_tracker.log_table('SampleData',df)
+                my_tracker.log_table('SampleData', data_frame=df)
 
         Args:
             title (str, optional): Title of the table. Defaults to None.


### PR DESCRIPTION
*Issue #, if available:*
Got the following error when trying to use `my_tracker.log_table('SampleData', df)`:
```
ValueError: Table values should be list. i.e. {"x": [1,2,3]}, instead was <class 'pandas.core.series.Series'>
```

*Description of changes:*
Changed documentation to `my_tracker.log_table('SampleData', data_frame=df)`, passing the data_frame parameter correctly.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md#committing-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-experiments/blob/main/README.rst) and [API docs](https://github.com/aws/sagemaker-experiments/tree/main/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.