### PR TITLE
fix: fetch all during release

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -38,13 +38,15 @@ def get_version_increment_type(last_version):
 
 
 def fetch_latest_and_verify(expected_version_tag):
-    check_output(["git", "fetch"])
+    check_output(["git", "fetch", "--all"])
     latest_version = get_current_version()
     if latest_version != expected_version_tag:
         raise ValueError(f"Expected {expected_version_tag} to be latest tag, but was {latest_version}")
 
 
 def get_current_version():
+    # ensure tags retrieved
+    check_output(["git", "fetch", "--all"])
     # get the last release tag
     stdout = check_output(["git", "describe", "--abbrev=0", "--tags"])
     stdout = stdout.decode("utf-8")


### PR DESCRIPTION
*Issue #, if available:* fix `No names found, cannot describe anything.` error during release action i.e. https://github.com/aws/sagemaker-experiments/actions/runs/4895788454/jobs/8742195201

*Description of changes:* call fetch --all to retrieve tags

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md#committing-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-experiments/blob/main/README.rst) and [API docs](https://github.com/aws/sagemaker-experiments/tree/main/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.