### PR TITLE
fix readme description syntax error causing release action to fail

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,7 @@
     :alt: SageMaker
     :target: https://aws.amazon.com/sagemaker/
 
-================================
 **NOTE:** Use the SageMaker `SDK <https://sagemaker.readthedocs.io/en/v2.125.0/experiments/sagemaker.experiments.html>`_ to use SageMaker Experiments. This repository will not be up to date with the latest product improvements. Link to `developer guide <https://docs.aws.amazon.com/sagemaker/latest/dg/experiments.html>`_. 
-================================
 
 ================================
 SageMaker Experiments Python SDK


### PR DESCRIPTION
*Issue #, if available:* no issue

*Description of changes:* release task is currently failing due to a syntax error in the README.rst see https://github.com/aws/sagemaker-experiments/actions/runs/4994718175/jobs/8946259829

*Testing done:* test release

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-experiments/blob/main/CONTRIBUTING.md#committing-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-experiments/blob/main/README.rst) and [API docs](https://github.com/aws/sagemaker-experiments/tree/main/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.